### PR TITLE
Update dependency for DerelictUtil

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,6 @@
     "targetPath": "lib",
 
     "dependencies": {
-        "derelict-util": "~>2.0.6"
+        "derelict-util": "~>2.1.0"
     }
 }


### PR DESCRIPTION
This request enables to use DerelictFT with the latest version of DerelictUtil (2.1.0).